### PR TITLE
Google Search component

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# EditorConfig is awesome: http://EditorConfig.org
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+*.log
+*.js
+bundle.css
+*.html
+!karma.conf.js

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# component-search
+# component-google-search
+
+Search component based on Google Custom Search.

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+SSH_KEY="${1:-/root/.ssh/id_rsa}"
+DOCKER_IMAGE="economistprod/node4-base"
+HOST_IP=$(ip route get 1 | awk '{print $NF;exit}')
+SINOPIA_URL="http://${HOST_IP}:4873"
+
+[[ ${NPM_TOKEN:-} = '' ]] && { echo "NPM_TOKEN empty"; exit 1; }
+[[ ${SAUCE_ACCESS_KEY:-} = '' ]] && { echo "SAUCE_ACCESS_KEY empty"; exit 2; }
+[[ ${SAUCE_USERNAME:-} = '' ]] && { echo "SAUCE_USERNAME empty"; exit 3; }
+
+docker pull "${DOCKER_IMAGE}"
+
+exec docker run \
+    -v "${SSH_KEY}":/root/.ssh/id_rsa \
+    -v "$(pwd)":/code \
+    -e NODE_ENV=${NODE_ENV:-test} \
+    "${DOCKER_IMAGE}" \
+    /bin/sh -cx "\
+        trap 'chmod 777 node_modules -R' EXIT && \
+        cd /code && \
+        umask 000 && \
+        printf \"@economist:registry=https://registry.npmjs.org/\n//registry.npmjs.org/:_authToken=${NPM_TOKEN}\n\" > ~/.npmrc && \
+        (curl -I ${SINOPIA_URL} --max-time 5 && npm set registry ${SINOPIA_URL} && echo \"Using sinopia cache registry available on ${SINOPIA_URL}\" || true) && \
+        npm i && \
+        npm run doc:js && \
+        SAUCE_USERNAME=${SAUCE_USERNAME} SAUCE_ACCESS_KEY=${SAUCE_ACCESS_KEY} npm t && \
+        { git config --global user.email 'ecprod@economist.com'; git config --global user.name 'GoCD'; true; } && \
+        { [ \"$(git rev-parse --abbrev-ref HEAD)\" != \"master\" ] || npm run pages; } ; \
+        RETURN_CODE=\$?; \
+        echo \"Build finished with status \${RETURN_CODE}\"; \
+        exit \${RETURN_CODE}
+    ";
+
+

--- a/example.css
+++ b/example.css
@@ -1,0 +1,10 @@
+@import './index';
+
+.search__example-container {
+  position: relative;
+  width: 100%;
+  background: var(--color-kiev);
+  height: 64px;
+  font-family: var(--fontfamily-body);
+  -webkit-font-smoothing: antialiased;
+}

--- a/example.es6
+++ b/example.es6
@@ -1,0 +1,6 @@
+import React from 'react';
+import Search from './index';
+
+export default(
+  <Search />
+);

--- a/example.es6
+++ b/example.es6
@@ -1,5 +1,5 @@
 import React from 'react';
-import Search from './index';
+import GoogleSearch from './index';
 
 export default(
   <div className="search__example-container">
@@ -7,7 +7,7 @@ export default(
       <tbody>
         <tr>
           <td style={{ width: '100%' }}>Just some placeholder text</td>
-          <td><Search /></td>
+          <td><GoogleSearch /></td>
         </tr>
       </tbody>
     </table>

--- a/example.es6
+++ b/example.es6
@@ -2,5 +2,14 @@ import React from 'react';
 import Search from './index';
 
 export default(
-  <Search />
+  <div className="search__example-container">
+    <table>
+      <tbody>
+        <tr>
+          <td style={{ width: '100%' }}>Just some placeholder text</td>
+          <td><Search /></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
 );

--- a/example.es6
+++ b/example.es6
@@ -6,7 +6,7 @@ export default(
     <table>
       <tbody>
         <tr>
-          <td style={{ width: '100%' }}>Just some placeholder text</td>
+          <td style={{ width: '100%', color: 'white' }}>Just some placeholder text</td>
           <td><GoogleSearch /></td>
         </tr>
       </tbody>

--- a/index.css
+++ b/index.css
@@ -1,0 +1,164 @@
+@import "@economist/component-palette";
+@import "@economist/component-typography";
+@import "@economist/component-loading";
+
+:root {
+  --search-speed-animation: 0.1s;
+}
+
+.search {
+  display: table;
+  font-size: 1em;
+  color: var(--search__color, var(--color-thimphu));
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  height: 100%;
+  border-collapse: collapse;
+  margin-right: 0.5em;
+}
+
+.search__show-field-group {
+  display: table-row;
+}
+
+.search__magnifier,
+.search__search-box,
+.search__search-label,
+.search__search-close,
+.search__preloader {
+  display: table-cell;
+  vertical-align: middle;
+  color: var(--search__color, var(--color-thimphu));
+}
+
+.search__search-label,
+.search__search-close,
+.search__preloader {
+  width: 50px;
+  box-sizing: border-box;
+}
+
+.search--open .search__search-box {
+  width: 100%;
+}
+
+.search--close .search__search-close {
+  display: none;
+}
+
+.search--close {
+  background: var(--search--close__background, var(--color-kiev));
+  transition: left var(--search-speed-animation);
+}
+
+.search--open {
+  background: var(--search--open__background, var(--color-thimphu));
+  transition: left var(--search-speed-animation);
+}
+
+.search--close #___gcse_0 {
+  display: none;
+}
+
+.search__search-box {
+  background: var(--search--close__background, var(--color-thimphu));
+}
+
+td.gsc-input {
+  background: none !important;
+}
+
+.search--close .search__search-box {
+  width: 0px;
+  transition: width var(--search-speed-animation);
+  overflow: hidden;
+}
+
+.search--open .search__search-box {
+  width: 1000px;
+  transition: width var(--search-speed-animation);
+}
+
+.search__search-label,
+input.gsc-input input {
+  font-size: var(--search__search-label__font-size, var(--text-size-step--1));
+  height: var(--search__search-label__height, var(--text-size-step--1));
+}
+
+.search--loading .search__search-label,
+.search--open .search__search-label {
+  display: none;
+}
+
+.search__search-label {
+  text-decoration: none;
+  text-align: center;
+  background: var(--search--close__background, var(--color-kiev));
+}
+
+.search--open .search__search-close {
+  background: var(--searc--open__search-close__background, var(--color-kiev));
+  padding: 1em;
+}
+
+.search--open .Icon-magnifier use{
+  fill: var(--search__icon-magnifier-open-color,  var(--color-kiev));
+}
+
+.search__search-close .Icon-close use {
+  fill: var(--search__icon-magnifier-close-color,  var(--color-thimphu));
+}
+
+
+.gsc-input {
+  width: 100%;
+}
+
+.search .gsc-search-box {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  float: left;
+}
+
+input.gsc-input,
+input.gsc-input input {
+  border: none !important;
+}
+
+input.gsc-input {
+  color: var(--search__input-color, var(--color-kiev));
+  padding: 0 !important;
+}
+
+.gsc-search-button,
+.gsc-clear-button {
+  display: none;
+}
+
+.search__preloader {
+  position: relative;
+  overflow: hidden;
+}
+
+.search__preloader {
+  display: none;
+}
+
+.search--loading .search__preloader {
+  display: block;
+  height: 100%;
+}
+
+.search--loading .search__search-close {
+  display: none;
+}
+
+.search__preloader .loading {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  font-size: 0.4em;
+}

--- a/index.css
+++ b/index.css
@@ -113,6 +113,11 @@ td.gsc-input {
   fill: var(--search__icon-magnifier-open-color,  var(--color-kiev));
 }
 
+.search--open .search__magnifier {
+  min-width: 50px;
+  text-align: center;
+}
+
 .search__search-close .Icon-close,
 .search__search-close .Icon-close use {
   fill: var(--search__icon-magnifier-close-color,  var(--color-thimphu));
@@ -170,5 +175,9 @@ input.gsc-input {
 @media (width<=767px){
   .search__search-label {
     display: none;
+  }
+  .search__magnifier {
+    min-width: 50px;
+    text-align: center;
   }
 }

--- a/index.css
+++ b/index.css
@@ -2,9 +2,9 @@
 @import "@economist/component-typography";
 @import "@economist/component-loading";
 
-:root {
+/*:root {
   --search-speed-animation: 0.1s;
-}
+}*/
 
 .search {
   display: table;
@@ -16,7 +16,11 @@
   right: 0;
   height: 100%;
   border-collapse: collapse;
-  margin-right: 0.5em;
+  left: auto;
+}
+
+.search .error--message {
+  color: var(--color-economist);
 }
 
 .search__show-field-group {
@@ -36,26 +40,28 @@
 .search__search-label,
 .search__search-close,
 .search__preloader {
-  width: 50px;
+  min-width: 50px;
   box-sizing: border-box;
+  text-align: center;
 }
 
 .search--open .search__search-box {
   width: 100%;
 }
-
+.search--close .search__search-box,
 .search--close .search__search-close {
   display: none;
 }
 
 .search--close {
   background: var(--search--close__background, var(--color-kiev));
-  transition: left var(--search-speed-animation);
+  /*transition: left var(--search-speed-animation);*/
 }
 
 .search--open {
   background: var(--search--open__background, var(--color-thimphu));
-  transition: left var(--search-speed-animation);
+  /*transition: left var(--search-speed-animation);*/
+  left: 0;
 }
 
 .search--close #___gcse_0 {
@@ -72,13 +78,14 @@ td.gsc-input {
 
 .search--close .search__search-box {
   width: 0px;
-  transition: width var(--search-speed-animation);
+  /*transition: width var(--search-speed-animation);*/
   overflow: hidden;
+  background: none;
 }
 
 .search--open .search__search-box {
-  width: 1000px;
-  transition: width var(--search-speed-animation);
+  width: 100%;
+  /*transition: width var(--search-speed-animation);*/
 }
 
 .search__search-label,
@@ -100,17 +107,17 @@ input.gsc-input input {
 
 .search--open .search__search-close {
   background: var(--searc--open__search-close__background, var(--color-kiev));
-  padding: 1em;
 }
 
-.search--open .Icon-magnifier use{
+.search--open .Icon-magnifier,
+.search--open .Icon-magnifier use {
   fill: var(--search__icon-magnifier-open-color,  var(--color-kiev));
 }
 
+.search__search-close .Icon-close,
 .search__search-close .Icon-close use {
   fill: var(--search__icon-magnifier-close-color,  var(--color-thimphu));
 }
-
 
 .gsc-input {
   width: 100%;
@@ -161,4 +168,10 @@ input.gsc-input {
   top: 0;
   bottom: 0;
   font-size: 0.4em;
+}
+
+@media (width<=767px){
+  .search__search-label {
+    display: none;
+  }
 }

--- a/index.css
+++ b/index.css
@@ -88,8 +88,7 @@ td.gsc-input {
   /*transition: width var(--search-speed-animation);*/
 }
 
-.search__search-label,
-input.gsc-input input {
+.search__search-label {
   font-size: var(--search__search-label__font-size, var(--text-size-step--1));
   height: var(--search__search-label__height, var(--text-size-step--1));
 }
@@ -130,14 +129,12 @@ input.gsc-input input {
   float: left;
 }
 
-input.gsc-input,
-input.gsc-input input {
-  border: none !important;
-}
-
 input.gsc-input {
+  border: none !important;
   color: var(--search__input-color, var(--color-kiev));
   padding: 0 !important;
+  outline: none;
+  font-size: 1em;
 }
 
 .gsc-search-button,

--- a/index.es6
+++ b/index.es6
@@ -1,23 +1,85 @@
 import React from 'react';
+import Icon from '@economist/component-icon';
+import Loading from '@economist/component-loading';
+import promisescript from 'promisescript';
 /* eslint-disable no-undef, no-underscore-dangle, id-match, id-length */
 export default class Search extends React.Component {
 
-  showSearchField() {
+  static get propTypes() {
+    return {
+      enableHistory: React.PropTypes.bool,
+      noResultsString: React.PropTypes.string,
+      newWindow: React.PropTypes.bool,
+      gname: React.PropTypes.string,
+      queryParameterName: React.PropTypes.string,
+      language: React.PropTypes.string,
+      resultsUrl: React.PropTypes.string,
+    };
+  }
+
+  static get defaultProps() {
+    return {
+      enableHistory: true,
+      noResultsString: `Your query returned no results. Please try a
+      different search term. (Did you check your spelling? You can also
+        try rephrasing your query or using more general search terms.)`,
+      newWindow: false,
+      gname: 'economist-search',
+      queryParameterName: 'ss',
+      language: 'en',
+      resultsUrl: 'http://www.economist.com/search/',
+    };
+  }
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      javascritEnabled: true,
+      statusClassName: 'search--close',
+      searchTerm: '',
+    };
+  }
+
+  componentDidMount() {
+    this.hideNoJSForm();
+  }
+
+  showSearchFieldHandler(e) {
+    e.stopPropagation();
+    e.preventDefault();
+    this.setState({
+      statusClassName: 'search--loading',
+    });
+    return this.ensureScriptHasLoaded().then(() => (
+      this.setState({
+        statusClassName: 'search--open',
+      })
+    ));
+  }
+
+  clearSearchField() {
+    this.setState({
+      searchTerm: '',
+      statusClassName: 'search--close',
+    });
+    document.querySelector('.search input.gsc-input').value = '';
+  }
+
+  ensureScriptHasLoaded() {
+    const self = this;
     function renderSearchElement() {
       google.search.cse.element.render(
         {
-          div: 'default',
+          div: 'google-search-box',
           tag: 'searchbox-only',
           attributes: {
-            enableHistory: true,
-            noResultsString: `Your query returned no results. Please try a
-            different search term. (Did you check your spelling? You can also
-              try rephrasing your query or using more general search terms.)`,
-            newWindow: false,
-            gname: 'economist-search',
-            queryParameterName: 'ss',
-            language: 'en',
-            resultsUrl: '/search/',
+            enableHistory: self.props.enableHistory,
+            noResultsString: self.props.noResultsString,
+            newWindow: self.props.newWindow,
+            gname: self.props.gname,
+            queryParameterName: self.props.queryParameterName,
+            language: self.props.language,
+            resultsUrl: self.props.resultsUrl,
           },
         });
     }
@@ -30,25 +92,59 @@ export default class Search extends React.Component {
       }
     }
 
-    window.__gcse = {
-      parsetags: 'explicit',
-      callback: myCallback,
-    };
+    if (!this.script) {
+      window.__gcse = {
+        parsetags: 'explicit',
+        callback: myCallback,
+      };
+      const cx = '013751040265774567329:pqjb-wvrj-q';
+      const protocol = (document.location.protocol) === 'https:' ? 'https:' : 'http:';
+      const src = `${protocol}//www.google.com/cse/cse.js?cx=${cx}`;
+      this.script = promisescript({
+        url: src,
+        type: 'script',
+      }).catch((e) => {
+        console.error('An error loading or executing Google Custom Search: ', e.message);
+      });
+    }
+    return this.script;
+  }
 
-    const cx = '013751040265774567329:pqjb-wvrj-q';
-    const gcse = document.createElement('script'); gcse.type = 'text/javascript'; gcse.async = true;
-    const protocol = (document.location.protocol === 'https:' ? 'https:' : 'http:');
-    gcse.src = `${protocol}//www.google.com/cse/cse.js?cx=${cx}`;
-    const s = document.getElementsByTagName('script')[0];
-    s.parentNode.insertBefore(gcse, s);
+  hideNoJSForm() {
+    this.setState({
+      javascritEnabled: true,
+    });
   }
 
   render() {
-    return (<div>
-              <button type="button" onClick={this.showSearchField.bind(this)}>
-                Click Me to Show Custom Search Engine!
-              </button>
-              <div id="default"></div>
+    return (<div className={`search ${this.state.statusClassName}`}>
+              <div className="search__show-field-group">
+                <a className="search__magnifier"
+                  onClick={this.showSearchFieldHandler.bind(this)}
+                  href={this.props.resultsUrl}
+                >
+                  <Icon icon="magnifier"
+                    color="white"
+                    size="28"
+                  />
+                </a>
+                <div className="search__search-box" id="google-search-box"></div>
+                <a className="search__search-label"
+                  onClick={this.showSearchFieldHandler.bind(this)}
+                  href={this.props.resultsUrl}
+                >
+                  Search
+                </a>
+                <div className="search__preloader"><Loading /></div>
+                <a className="search__search-close"
+                  onClick={this.clearSearchField.bind(this)}
+                >
+                  <Icon
+                    icon="close"
+                    size="28"
+                  />
+                </a>
+              </div>
             </div>
           );
   }

--- a/index.es6
+++ b/index.es6
@@ -3,7 +3,7 @@ import Icon from '@economist/component-icon';
 import Loading from '@economist/component-loading';
 import promisescript from 'promisescript';
 /* eslint-disable no-undef, no-underscore-dangle, id-match, id-length, no-console */
-export default class Search extends React.Component {
+export default class GoogleSearch extends React.Component {
 
   static get propTypes() {
     return {
@@ -17,6 +17,7 @@ export default class Search extends React.Component {
       cx: React.PropTypes.string,
       searchLabel: React.PropTypes.string,
       iconsSize: React.PropTypes.string,
+      googleScriptUrl: React.PropTypes.string,
     };
   }
 
@@ -34,7 +35,7 @@ export default class Search extends React.Component {
       cx: '013751040265774567329:pqjb-wvrj-q',
       searchLabel: 'Search',
       iconsSize: '28',
-      googleScriptURL: 'www.google.com/cse2/cse.js',
+      googleScriptUrl: 'www.google.com/cse/cse.js',
     };
   }
 
@@ -109,14 +110,30 @@ export default class Search extends React.Component {
         callback: myCallback,
       };
       const protocol = (document.location.protocol) === 'https:' ? 'https:' : 'http:';
-      const src = `${protocol}//${this.props.googleScriptURL}?cx=${this.props.cx}`;
+      const src = `${protocol}//${this.props.googleScriptUrl}?cx=${this.props.cx}`;
       this.script = promisescript({
         url: src,
         type: 'script',
       }).catch((e) => {
-        // Let provide a fallback
+        // Let provide a fallback if we can't load the GCS script.
+        const fallbackHTML = `
+            <form acceptCharset="UTF-8" method="GET"
+              id="search-theme-form" action="${this.props.resultsUrl}"
+              class="gsc-input"
+            >
+              <input
+                type="text" maxLength="128" name="${this.props.queryParameterName}"
+                id="edit-search-theme-form-1"
+                value=""
+                title="Enter the terms you wish to search for."
+                class="gsc-input"
+              />
+              <input type="hidden" name="cx"
+                value="${this.props.cx}" id="edit-cx"
+              />
+            </form>`;
         this.setState({
-          fallbackHTML: `<b>Cool</b>`,
+          fallbackHTML,
         });
         console.error('An error occurs loading or executing Google Custom Search: ', e.message);
       });
@@ -139,7 +156,12 @@ export default class Search extends React.Component {
                 <div
                   className="search__search-box"
                   id="google-search-box"
-                >{this.state.fallbackHTML}</div>
+                >
+                  <div className="fallback"
+                    dangerouslySetInnerHTML={{__html: this.state.fallbackHTML}}
+                  >
+                  </div>
+                </div>
                 <a className="search__search-label"
                   onClick={this.showSearchFieldHandler.bind(this)}
                   href={this.props.resultsUrl}

--- a/index.es6
+++ b/index.es6
@@ -1,7 +1,55 @@
 import React from 'react';
-
+/* eslint-disable no-undef, no-underscore-dangle, id-match, id-length */
 export default class Search extends React.Component {
+
+  showSearchField() {
+    function renderSearchElement() {
+      google.search.cse.element.render(
+        {
+          div: 'default',
+          tag: 'searchbox-only',
+          attributes: {
+            enableHistory: true,
+            noResultsString: `Your query returned no results. Please try a
+            different search term. (Did you check your spelling? You can also
+              try rephrasing your query or using more general search terms.)`,
+            newWindow: false,
+            gname: 'economist-search',
+            queryParameterName: 'ss',
+            language: 'en',
+            resultsUrl: '/search/',
+          },
+        });
+    }
+
+    function myCallback() {
+      if (document.readyState === 'complete') {
+        renderSearchElement();
+      } else {
+        google.setOnLoadCallback(renderSearchElement, true);
+      }
+    }
+
+    window.__gcse = {
+      parsetags: 'explicit',
+      callback: myCallback,
+    };
+
+    const cx = '013751040265774567329:pqjb-wvrj-q';
+    const gcse = document.createElement('script'); gcse.type = 'text/javascript'; gcse.async = true;
+    const protocol = (document.location.protocol === 'https:' ? 'https:' : 'http:');
+    gcse.src = `${protocol}//www.google.com/cse/cse.js?cx=${cx}`;
+    const s = document.getElementsByTagName('script')[0];
+    s.parentNode.insertBefore(gcse, s);
+  }
+
   render() {
-    return (<p>Cool</p>);
+    return (<div>
+              <button type="button" onClick={this.showSearchField.bind(this)}>
+                Click Me to Show Custom Search Engine!
+              </button>
+              <div id="default"></div>
+            </div>
+          );
   }
 }

--- a/index.es6
+++ b/index.es6
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export default class Search extends React.Component {
+  render() {
+    return (<p>Cool</p>);
+  }
+}

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,75 @@
+module.exports = function(config) {
+  const localBrowsers = ['Chrome'];
+  const sauceLabsBrowsers = {
+    SauceChromeLatest: {
+      base: 'SauceLabs',
+      browserName: 'Chrome',
+    },
+    SauceFirefoxLatest: {
+      base: 'SauceLabs',
+      browserName: 'Firefox',
+    },
+    SauceSafariLatest: {
+      base: 'SauceLabs',
+      browserName: 'Safari',
+    },
+    SauceInternetExplorerLatest: {
+      base: 'SauceLabs',
+      browserName: 'Internet Explorer',
+    },
+    SauceEdgeLatest: {
+      base: 'SauceLabs',
+      browserName: 'MicrosoftEdge',
+    },
+    SauceIphoneLatest: {
+      base: 'SauceLabs',
+      browserName: 'iPad',
+    },
+    SauceAndroidLatest: {
+      base: 'SauceLabs',
+      browserName: 'Android',
+    },
+  };
+  config.set({
+    basePath: '',
+    browsers: localBrowsers,
+    logLevel: config.LOG_DEBUG,
+    frameworks: ['mocha', 'chai'],
+    files: [
+      require.resolve('chai-spies/chai-spies'),
+      require.resolve('chai-things/lib/chai-things'),
+      'testbundle.js'
+    ],
+    exclude: [],
+    preprocessors: {},
+    reporters: ['progress'],
+    port: 9876,
+    colors: true,
+    concurrency: 3,
+    logLevel: config.LOG_INFO,
+    autoWatch: false,
+    captureTimeout: 1000 * 60 * 2,
+    browserDisconnectTimeout: 1000 * 60 * 2,
+    browserNoActivityTimeout: 1000 * 60 * 2,
+    singleRun: true
+  });
+
+  if (process.env.SAUCE_ACCESS_KEY) {
+    config.reporters.push('saucelabs');
+    config.set({
+      customLaunchers: sauceLabsBrowsers,
+      browsers: Object.keys(sauceLabsBrowsers),
+      sauceLabs: {
+        testName: require('./package').name,
+        startConnect: true,
+        username: process.env.SAUCE_USERNAME || 'economist',
+        build: (function() {
+          if (process.env.GO_PIPELINE_NAME && process.env.GO_PIPELINE_LABEL) {
+            return process.env.GO_PIPELINE_NAME + '-' + process.env.GO_PIPELINE_LABEL;
+          }
+          return 'localbuild-' + new Date().toJSON();
+        })()
+      }
+    });
+  }
+};

--- a/package.json
+++ b/package.json
@@ -126,7 +126,8 @@
     "watch": "parallelshell 'npm run doc:watch' 'npm run prepublish:watch' 'npm run serve'"
   },
   "dependencies": {
-    "react": "^0.14.3"
+    "react": "^0.14.3",
+    "react-select": "^0.9.1"
   },
   "devDependencies": {
     "@economist/component-devpack": "^3.6.0",

--- a/package.json
+++ b/package.json
@@ -126,6 +126,10 @@
     "watch": "parallelshell 'npm run doc:watch' 'npm run prepublish:watch' 'npm run serve'"
   },
   "dependencies": {
+    "@economist/component-icon": "^3.6.6",
+    "@economist/component-palette": "^1.3.0",
+    "@economist/component-typography": "^1.5.0",
+    "promisescript": "^1.1.0",
     "react": "^0.14.3",
     "react-select": "^0.9.1"
   },

--- a/package.json
+++ b/package.json
@@ -49,6 +49,9 @@
     ],
     "js": [
       {
+        "src": "./node_modules/svg4everybody/dist/svg4everybody.min.js"
+      },
+      {
         "src": "./node_modules/mocha/mocha.js"
       },
       {
@@ -72,6 +75,8 @@
       },
       {
         "contents": "if(document.getElementById('mocha')){mocha.checkLeaks();mocha.run();}"
+      },{
+        "contents": "svg4everybody();"
       }
     ],
     "sections": [
@@ -159,6 +164,7 @@
     "parallelshell": "^2.0.0",
     "pre-commit": "^1.0.10",
     "react": "^0.14.0",
+    "svg4everybody": "^2.0.1",
     "watchify": "^3.4.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
-  "name": "@economist/component-search",
+  "name": "@economist/component-google-search",
   "version": "1.0.0",
-  "description": "A search field with autocompletition",
+  "description": "A search field with autocompletition based on GCS",
   "author": "The Economist (http://economist.com)",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/economist-components/component-search.git"
+    "url": "git+https://github.com/economist-components/component-google-search.git"
   },
-  "homepage": "https://github.com/economist-components/component-search#readme",
+  "homepage": "https://github.com/economist-components/component-google-search#readme",
   "bugs": {
-    "url": "https://github.com/economist-components/component-search/issues"
+    "url": "https://github.com/economist-components/component-google-search/issues"
   },
   "main": "index.js",
   "files": [
@@ -75,7 +75,8 @@
       },
       {
         "contents": "if(document.getElementById('mocha')){mocha.checkLeaks();mocha.run();}"
-      },{
+      },
+      {
         "contents": "svg4everybody();"
       }
     ],
@@ -164,6 +165,7 @@
     "parallelshell": "^2.0.0",
     "pre-commit": "^1.0.10",
     "react": "^0.14.0",
+    "react-addons-test-utils": "^0.14.3",
     "svg4everybody": "^2.0.1",
     "watchify": "^3.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,0 +1,165 @@
+{
+  "name": "@economist/component-search",
+  "version": "1.0.0",
+  "description": "A search field with autocompletition",
+  "author": "The Economist (http://economist.com)",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/economist-components/component-search.git"
+  },
+  "homepage": "https://github.com/economist-components/component-search#readme",
+  "bugs": {
+    "url": "https://github.com/economist-components/component-search/issues"
+  },
+  "main": "index.js",
+  "files": [
+    "*.js",
+    "*.es6",
+    "*.css",
+    "assets/*",
+    "!karma.conf.js",
+    "!testbundle.js"
+  ],
+  "browserify": {
+    "transform": [
+      "babelify"
+    ]
+  },
+  "babel": {
+    "stage": 0,
+    "loose": "all",
+    "compact": false
+  },
+  "eslintConfig": {
+    "extends": [
+      "strict",
+      "strict-react"
+    ]
+  },
+  "devpack-doc": {
+    "demohtml": {
+      "cmd": "babel-node -p \"require('react').renderToString(require('./example'))\""
+    },
+    "css": [
+      {
+        "src": "./node_modules/mocha/mocha.css"
+      },
+      "./bundle.css"
+    ],
+    "js": [
+      {
+        "src": "./node_modules/mocha/mocha.js"
+      },
+      {
+        "src": "./node_modules/chai/chai.js"
+      },
+      {
+        "src": "./node_modules/chai-things/lib/chai-things.js"
+      },
+      {
+        "src": "./node_modules/chai-spies/chai-spies.js"
+      },
+      {
+        "contents": "chai.should();mocha.setup('bdd');"
+      },
+      "./testbundle.js",
+      {
+        "contents": "window.React = require('react');"
+      },
+      {
+        "contents": "require('react').render(require('example'),document.getElementById('component-preview'));"
+      },
+      {
+        "contents": "if(document.getElementById('mocha')){mocha.checkLeaks();mocha.run();}"
+      }
+    ],
+    "sections": [
+      {
+        "title": "Readme",
+        "type": "markdown",
+        "src": "./README.md"
+      },
+      {
+        "title": "Example Code",
+        "type": "code",
+        "src": "./example.es6"
+      },
+      {
+        "title": "Tests",
+        "type": "html",
+        "contents": "<div id='mocha' class='test-output'></div>"
+      }
+    ]
+  },
+  "watch": {
+    "doc:html": [
+      "README.md",
+      "./*.js",
+      "package.json"
+    ]
+  },
+  "config": {
+    "lint_opts": "--ignore-path .gitignore --ext .es6",
+    "testbundle_opts": "-r react -r .:./index.es6 -r ./example.js:example ./test/index.js -o testbundle.js",
+    "ghpages_files": "*.html *.css *.js assets/"
+  },
+  "scripts": {
+    "ci": "./build.sh",
+    "doc": "parallelshell 'npm run doc:html' 'npm run doc:js' 'npm run doc:css'",
+    "doc:css": "cssnext --sourcemap example.css bundle.css",
+    "doc:css:watch": "npm run doc:css -- --watch",
+    "doc:html": "npm-assets . && devpack-doc index standalone",
+    "doc:html:watch": "npm-watch",
+    "doc:js": "npm run prepublish && browserify -d $npm_package_config_testbundle_opts",
+    "doc:js:watch": "watchify $npm_package_config_testbundle_opts",
+    "doc:watch": "parallelshell 'npm run doc:html:watch' 'npm run doc:js:watch' 'npm run doc:css:watch'",
+    "lint": "eslint $npm_package_config_lint_opts .",
+    "pages": "git stash save -u pages-stash && git branch -D gh-pages; git checkout --orphan gh-pages && git add -f $npm_package_config_ghpages_files && git commit -anm'ghpages' && git push origin HEAD:gh-pages -f",
+    "prepages": "npm run doc",
+    "prepublish": "babel . -d . -x .es6 --ignore node_modules",
+    "prepublish:watch": "npm run prepublish -- -w",
+    "pretest": "npm run lint",
+    "provision": "devpack-configure ./package.json",
+    "serve": "browser-sync start --server --files '*.{html,js}'",
+    "test": "karma start",
+    "watch": "parallelshell 'npm run doc:watch' 'npm run prepublish:watch' 'npm run serve'"
+  },
+  "dependencies": {
+    "react": "^0.14.3"
+  },
+  "devDependencies": {
+    "@economist/component-devpack": "^3.6.0",
+    "babel": "^5.8.23",
+    "babelify": "^6.3.0",
+    "browser-sync": "^2.8.2",
+    "browserify": "^11.0.1",
+    "chai": "^3.2.0",
+    "chai-spies": "^0.6.0",
+    "chai-things": "^0.2.0",
+    "cssnext": "^1.8.4",
+    "eslint": "^1.3.1",
+    "eslint-config-strict": "^5.0.0",
+    "eslint-config-strict-react": "^2.0.0",
+    "eslint-plugin-filenames": "^0.1.2",
+    "eslint-plugin-react": "^3.3.1",
+    "karma": "^0.13.10",
+    "karma-chai": "^0.1.0",
+    "karma-chrome-launcher": "^0.2.1",
+    "karma-mocha": "^0.2.0",
+    "karma-sauce-launcher": "^0.3.0",
+    "mocha": "^2.2.5",
+    "npm-assets": "^0.1.0",
+    "npm-watch": "0.0.1",
+    "parallelshell": "^2.0.0",
+    "pre-commit": "^1.0.10",
+    "react": "^0.14.0",
+    "watchify": "^3.4.0"
+  },
+  "peerDependencies": {
+    "react": "^0.14.0"
+  },
+  "pre-commit": [
+    "lint"
+  ]
+}

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,3 @@
-# component-search
+# component-google-search
 
-Component Search provides a searchable field with autocompletition.
+Search component based on Google Custom Search.

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,3 @@
+# component-search
+
+Component Search provides a searchable field with autocompletition.

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,1 @@
+{"extends":["strict","strict-react","strict/mocha"]}

--- a/test/index.es6
+++ b/test/index.es6
@@ -1,2 +1,54 @@
-describe('Component search', () => {
+import GoogleSearch from '../index.es6';
+import TestUtils from 'react-addons-test-utils';
+import React from 'react';
+/* eslint-disable newline-after-var, id-length */
+describe(`A Google Search component`, () => {
+  describe(`is a React component`, () => {
+    it('is compatible with React.Component', () => {
+      GoogleSearch.should.be.a('function').and.respondTo('render');
+    });
+    it(`it renders a React element`, () => {
+      React.isValidElement(<GoogleSearch/>).should.equal(true);
+    });
+    it(`it has a magnifier icon, a label, a preloader, a close button`, () => {
+      const shallowRenderer = TestUtils.createRenderer();
+      shallowRenderer.render(React.createElement(GoogleSearch, {
+        enableHistory: true,
+        noResultsString: `Your query returned no results. Please try a
+        different search term. (Did you check your spelling? You can also
+          try rephrasing your query or using more general search terms.)`,
+        newWindow: false,
+        gname: 'economist-search',
+        queryParameterName: 'ss',
+        language: 'en',
+        resultsUrl: 'http://www.economist.com/search/',
+        cx: '013751040265774567329:pqjb-wvrj-q',
+        searchLabel: 'Search',
+        iconsSize: '28',
+        googleScriptUrl: 'www.google.com/cse/cse.js',
+      }));
+      const search = shallowRenderer.getRenderOutput();
+      const searchShowFieldGroup = search.props.children;
+      const searchMagnifier = searchShowFieldGroup.props.children[0];
+      const searchSearchBox = searchShowFieldGroup.props.children[1];
+      const searchSearchLabel = searchShowFieldGroup.props.children[2];
+      const searchPreloader = searchShowFieldGroup.props.children[3];
+      const searchSearchClose = searchShowFieldGroup.props.children[4];
+
+      search.props.className.indexOf('search').should.be.at.least(0);
+      searchShowFieldGroup.props.className.should.equal('search__show-field-group');
+      searchMagnifier.props.className.should.equal('search__magnifier');
+      searchMagnifier.type.should.equal('a');
+      searchMagnifier.props.href.should.equal('http://www.economist.com/search/');
+      searchSearchBox.props.className.should.equal('search__search-box');
+      searchSearchBox.props.id.should.equal('google-search-box');
+      searchSearchLabel.props.className.should.equal('search__search-label');
+      searchSearchLabel.type.should.equal('a');
+      searchSearchLabel.props.href.should.equal('http://www.economist.com/search/');
+      searchPreloader.props.className.should.equal('search__preloader');
+      searchSearchClose.props.className.should.equal('search__search-close');
+      searchSearchClose.type.should.equal('a');
+      searchSearchClose.props.onClick.name.should.equal('bound clearSearchField');
+    });
+  });
 });

--- a/test/index.es6
+++ b/test/index.es6
@@ -1,0 +1,2 @@
+describe('Component search', () => {
+});


### PR DESCRIPTION
Based on this prototype:

https://marvelapp.com/a4e1i6#8851176

The Google Search component provides:

- Async loading of the GCS script on demand with a preloader. GCS currently provide the autocompletion functionality on keyup.
- No-js functionality: If js is disabled magnifier icon and "Search" label act as links sending the user to the search page.
- Fallback is gcs script can't be loaded: a html form is injected, obviously there will be no autocompletion functionality but the user can anyway use the search functionality.

Personal note.
We should not use GCS for this component that, at the end, it just create GET request with parameters.
The current problem is that rewrite the autocompletion part it requires time that currently has not been allocated for this purpose, so I think the current implementation is an acceptable one for the allocated time.

