### PR TITLE
Fix tests and dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,6 @@
     "@economist/component-palette": "^1.3.0",
     "@economist/component-typography": "^1.5.0",
     "promisescript": "^1.1.0",
-    "react": "^0.14.3",
     "react-select": "^0.9.1"
   },
   "devDependencies": {

--- a/test/index.es6
+++ b/test/index.es6
@@ -48,7 +48,7 @@ describe(`A Google Search component`, () => {
       searchPreloader.props.className.should.equal('search__preloader');
       searchSearchClose.props.className.should.equal('search__search-close');
       searchSearchClose.type.should.equal('a');
-      searchSearchClose.props.onClick.name.should.equal('bound clearSearchField');
+      searchSearchClose.props.onClick.should.be.a('function');
     });
   });
 });


### PR DESCRIPTION
1. React should be in devDependencies and in peerDependencies;
2. Stop trusting chrome-specific `'bound <function name>'` format of `.name` properties in bound functions.