### PR TITLE
component-google-search: Refactor, removed all of the hide/show logic.

### DIFF
--- a/example.css
+++ b/example.css
@@ -12,3 +12,7 @@ body {
   font-family: var(--fontfamily-sans);
   -webkit-font-smoothing: antialiased;
 }
+
+#___gcse_0 {
+  width: 500px;
+}

--- a/index.css
+++ b/index.css
@@ -1,133 +1,30 @@
 @import "@economist/component-palette";
 @import "@economist/component-typography";
 
-.search {
-  display: table;
-  font-size: 1em;
-  color: var(--search__color, var(--color-thimphu));
-  height: 100%;
-  border-collapse: collapse;
-  left: auto;
-}
-
-.search .error--message {
-  color: var(--color-economist);
-}
-
-.search__show-field-group {
-  display: table-row;
-}
-
-.search__magnifier,
-.search__search-box,
-.search__search-label,
-.search__search-close,
-.search__preloader {
+.google-search {
   display: table-cell;
   vertical-align: middle;
   color: var(--search__color, var(--color-thimphu));
-}
-
-.search__search-label,
-.search__search-close,
-.search__preloader {
-  min-width: 50px;
-  box-sizing: border-box;
-  text-align: center;
-}
-
-.search__search-box {
-  width: 100%;
-}
-.search--close .search__search-box,
-.search--close .search__search-close {
-  display: none;
-}
-
-.search--open,
-.search--loading {
-  background: var(--search--open__background, var(--color-thimphu));
-  position: absolute;
-  top: 0;
-  left: 0;
-  bottom: 0;
-  right: 0;
-}
-
-.search--close #___gcse_0 {
-  display: none;
-}
-
-.search__search-box {
   background: var(--search--close__background, var(--color-thimphu));
+  width: 100%;
 }
 
 td.gsc-input {
   background: none !important;
 }
 
-.search--close .search__search-box {
-  width: 0px;
-  overflow: hidden;
-  background: none;
-}
-
-.search__search-label {
-  font-size: var(--search__search-label__font-size, var(--text-size-step--1));
-  height: var(--search__search-label__height, var(--text-size-step--1));
-}
-
-.search--loading .search__search-label,
-.search--open .search__search-label {
-  display: none;
-}
-
-.search__search-label {
-  text-decoration: none;
-  text-align: left;
-}
-
-.search__search-close {
-  background: var(--searc--open__search-close__background, var(--color-kiev));
-}
-
-.search--loading .Icon-magnifier,
-.search--open .Icon-magnifier {
-  fill: var(--search__icon-magnifier-open-color,  var(--color-kiev));
-}
-
-.search--loading .search__magnifier,
-.search--open .search__magnifier {
-  min-width: 50px;
-  text-align: center;
-}
-
-.search__search-close .Icon-close {
-  fill: var(--search__icon-magnifier-close-color,  var(--color-thimphu));
-}
-
-.gsc-input {
-  width: 100%;
-}
-
-.search .gsc-search-box {
+.google-search .gsc-search-box {
   margin: 0;
   padding: 0;
   width: 100%;
   float: left;
 }
 
-.search__magnifier {
-  vertical-align: middle;
-}
-
-.search--loading .search__magnifier,
-.search--open .search__magnifier,
 #google-search-box {
   border-top: 1px solid var(--search__border-top-color, var(--color-berlin));
 }
 
-.search input.gsc-input {
+.google-search input.gsc-input {
   border: none !important;
   color: var(--search__input-color, var(--color-kiev));
   padding: 0 !important;
@@ -135,37 +32,12 @@ td.gsc-input {
   font-size: 2em;
 }
 
+.gsc-input {
+  width: 100%;
+}
+
 .gsc-search-button,
 .gsc-clear-button {
   display: none;
-}
-
-.search__preloader {
-  position: relative;
-  overflow: hidden;
-}
-
-.search__preloader {
-  display: none;
-}
-
-.search--loading .search__preloader {
-  display: block;
-  height: 100%;
-}
-
-.search__preloader .loading {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  font-size: 0.4em;
-}
-
-.search__search-close {
-  height: var(--search__search-close-height, 64px);
-  width: var(--search__search-close-height, 64px);
-  display: flex;
-  align-items: center;
-  justify-content: center;
 }
 

--- a/index.es6
+++ b/index.es6
@@ -1,7 +1,8 @@
 import React from 'react';
-import Icon from '@economist/component-icon';
 import promisescript from 'promisescript';
 /* eslint-disable no-undef, no-underscore-dangle, id-match, id-length, no-console */
+
+let googleScript = null;
 export default class GoogleSearch extends React.Component {
 
   static get propTypes() {
@@ -14,8 +15,6 @@ export default class GoogleSearch extends React.Component {
       language: React.PropTypes.string,
       resultsUrl: React.PropTypes.string,
       cx: React.PropTypes.string,
-      searchLabel: React.PropTypes.string,
-      iconsSize: React.PropTypes.string,
       googleScriptUrl: React.PropTypes.string,
     };
   }
@@ -32,8 +31,6 @@ export default class GoogleSearch extends React.Component {
       language: 'en',
       resultsUrl: 'http://www.economist.com/search/',
       cx: '013751040265774567329:pqjb-wvrj-q',
-      searchLabel: 'Search',
-      iconsSize: '28',
       googleScriptUrl: 'www.google.com/cse/cse.js',
     };
   }
@@ -41,148 +38,99 @@ export default class GoogleSearch extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      statusClassName: 'search--close',
-      searchTerm: '',
       // useFallback by default on SS
       useFallback: (typeof window === 'undefined'),
     };
   }
 
-  showSearchFieldHandler(e) {
-    e.stopPropagation();
-    e.preventDefault();
-    this.setState({
-      statusClassName: 'search--loading',
-    });
-    this.ensureScriptHasLoaded().then(() => {
-      this.setState({
-        statusClassName: 'search--open',
+  componentDidMount() {
+    this.ensureScriptHasLoaded()
+      .then(() => this.displayGoogleSearch())
+      .then(() => this.focusSearchField())
+      .catch((err) => {
+        console.error(err);
+        this.setState({ useFallback: true });
       });
-      this.focusSearchField();
-    }).catch(() => {
-      this.focusSearchField();
-    });
-    // Required for preventDefault on Safari.
-    return false;
-  }
-
-  clearSearchField() {
-    this.setState({
-      searchTerm: '',
-      statusClassName: 'search--close',
-    });
-    if (this.state.useFallback) {
-      this.googleSearchInputFallbackInput.value = '';
-    } else if (this.googleSearchInput) {
-      this.googleSearchInput.value = '';
-    }
   }
 
   focusSearchField() {
-    if (this.state.useFallback) {
-      this.googleSearchInputFallbackInput.focus();
-    } else if (this.googleSearchInput) {
+    try {
       this.googleSearchInput.focus();
+    } catch (e) {
+      console.error(e);
     }
+  }
+
+  displayGoogleSearch() {
+    const config = {
+      div: 'google-search-box',
+      tag: 'searchbox-only',
+      attributes: {
+        enableHistory: this.props.enableHistory,
+        noResultsString: this.props.noResultsString,
+        newWindow: this.props.newWindow,
+        gname: this.props.gname,
+        queryParameterName: this.props.queryParameterName,
+        language: this.props.language,
+        resultsUrl: this.props.resultsUrl,
+      },
+    };
+    window.google.search.cse.element.render(config);
+    this.googleSearchInput = document.querySelector('.search .gsc-search-box input.gsc-input');
   }
 
   ensureScriptHasLoaded() {
-    if (!this.script) {
-      const config = {
-        div: 'google-search-box',
-        tag: 'searchbox-only',
-        attributes: {
-          enableHistory: this.props.enableHistory,
-          noResultsString: this.props.noResultsString,
-          newWindow: this.props.newWindow,
-          gname: this.props.gname,
-          queryParameterName: this.props.queryParameterName,
-          language: this.props.language,
-          resultsUrl: this.props.resultsUrl,
-        },
-      };
-      window.__gcse = {
-        parsetags: 'explicit',
-        callback: () => {
-          google.search.cse.element.render(config);
-          this.setState({
-            useFallback: false,
-          });
-          this.googleSearchInput = document.querySelector('.search .gsc-search-box input.gsc-input');
-          this.focusSearchField();
-        },
-      };
-      // Loading this script it provide us the only additional functionality
-      // of autocompletition that is probably achievable by custom code using
-      // the Google Search API (Probably paid version).
-      const protocol = (document.location.protocol) === 'https:' ? 'https:' : 'http:';
-      const src = `${protocol}//${this.props.googleScriptUrl}?cx=${this.props.cx}`;
-      this.script = promisescript({
-        url: src,
-        type: 'script',
-      }).catch((e) => {
-        this.setState({
-          useFallback: true,
+    if (!googleScript) {
+      googleScript = new Promise((resolve, reject) => {
+        window.__gcse = {
+          parsetags: 'explicit',
+          callback: resolve,
+        };
+        // Loading this script it provide us the only additional functionality
+        // of autocompletition that is probably achievable by custom code using
+        // the Google Search API (Probably paid version).
+        const protocol = (document.location.protocol) === 'https:' ? 'https:' : 'http:';
+        const src = `${protocol}//${this.props.googleScriptUrl}?cx=${this.props.cx}`;
+        promisescript({
+          url: src,
+          type: 'script',
+        }).catch((e) => {
+          reject(new Error(`An error occurs loading or executing Google Custom Search: ${e.message}`));
         });
-        this.focusSearchField();
-        console.error('An error occurs loading or executing Google Custom Search: ', e.message);
-        throw new Error(`An error occurs loading or executing Google Custom Search: ${e.message}`);
       });
     }
-    return this.script;
+    return googleScript;
   }
 
   render() {
-    return (<div className={`search ${this.state.statusClassName}`}>
-              <div className="search__show-field-group">
-                <a className="search__magnifier"
-                  onClick={this.showSearchFieldHandler.bind(this)}
-                  href={this.props.resultsUrl}
-                >
-                  <Icon icon="magnifier"
-                    color="white"
-                    size={this.props.iconsSize}
-                  />
-                </a>
-                <div
-                  className="search__search-box"
-                  id="google-search-box"
-                >
-                  <div className="fallback" style={{ display: (this.state.useFallback) ? 'block' : 'none' }}>
-                    <form acceptCharset="UTF-8" method="GET"
-                      id="search-theme-form" action={this.props.resultsUrl}
-                      className="gsc-input"
-                    >
-                      <input
-                        type="text" maxLength="128"
-                        name={this.props.queryParameterName}
-                        id="edit-search-theme-form-1"
-                        title="Enter the terms you wish to search for."
-                        className="gsc-input"
-                        ref={(ref) => this.googleSearchInputFallbackInput = ref}
-                      />
-                      <input type="hidden" name="cx"
-                        value={this.props.cx} id="edit-cx"
-                      />
-                    </form>
-                  </div>
-                </div>
-                <a className="search__search-label"
-                  onClick={this.showSearchFieldHandler.bind(this)}
-                  href={this.props.resultsUrl}
-                >
-                  {this.props.searchLabel}
-                </a>
-                <a className="search__search-close"
-                  onClick={this.clearSearchField.bind(this)}
-                >
-                  <Icon
-                    icon="close"
-                    size={this.props.iconsSize}
-                  />
-                </a>
-              </div>
-            </div>
-          );
+    return (
+      <div className="google-search" id="google-search-box">
+        <div className="fallback" style={{ display: (this.state.useFallback) ? 'block' : 'none' }}>
+          <form
+            acceptCharset="UTF-8"
+            method="GET"
+            id="search-theme-form"
+            action={this.props.resultsUrl}
+            className="gsc-input"
+          >
+            <input
+              type="text"
+              maxLength="128"
+              name={this.props.queryParameterName}
+              id="edit-search-theme-form-1"
+              title="Enter the terms you wish to search for."
+              className="gsc-input"
+              ref={(ref) => this.googleSearchInputFallbackInput = ref}
+            />
+            <input
+              id="edit-cx"
+              value={this.props.cx}
+              type="hidden"
+              name="cx"
+            />
+          </form>
+        </div>
+      </div>
+    );
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@economist/component-google-search",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "A search field with autocompletition based on GCS",
   "author": "The Economist (http://economist.com)",
   "license": "MIT",

--- a/test/index.es6
+++ b/test/index.es6
@@ -1,5 +1,4 @@
 import GoogleSearch from '../index.es6';
-import TestUtils from 'react-addons-test-utils';
 import React from 'react';
 /* eslint-disable newline-after-var, id-length */
 describe(`A Google Search component`, () => {
@@ -10,43 +9,6 @@ describe(`A Google Search component`, () => {
     it(`it renders a React element`, () => {
       React.isValidElement(<GoogleSearch/>).should.equal(true);
     });
-    it(`it has a magnifier icon, a label, a preloader, a close button`, () => {
-      const shallowRenderer = TestUtils.createRenderer();
-      shallowRenderer.render(React.createElement(GoogleSearch, {
-        enableHistory: true,
-        noResultsString: `Your query returned no results. Please try a
-        different search term. (Did you check your spelling? You can also
-          try rephrasing your query or using more general search terms.)`,
-        newWindow: false,
-        gname: 'economist-search',
-        queryParameterName: 'ss',
-        language: 'en',
-        resultsUrl: 'http://www.economist.com/search/',
-        cx: '013751040265774567329:pqjb-wvrj-q',
-        searchLabel: 'Search',
-        iconsSize: '28',
-        googleScriptUrl: 'www.google.com/cse/cse.js',
-      }));
-      const search = shallowRenderer.getRenderOutput();
-      const searchShowFieldGroup = search.props.children;
-      const searchMagnifier = searchShowFieldGroup.props.children[0];
-      const searchSearchBox = searchShowFieldGroup.props.children[1];
-      const searchSearchLabel = searchShowFieldGroup.props.children[2];
-      const searchSearchClose = searchShowFieldGroup.props.children[3];
-
-      search.props.className.indexOf('search').should.be.at.least(0);
-      searchShowFieldGroup.props.className.should.equal('search__show-field-group');
-      searchMagnifier.props.className.should.equal('search__magnifier');
-      searchMagnifier.type.should.equal('a');
-      searchMagnifier.props.href.should.equal('http://www.economist.com/search/');
-      searchSearchBox.props.className.should.equal('search__search-box');
-      searchSearchBox.props.id.should.equal('google-search-box');
-      searchSearchLabel.props.className.should.equal('search__search-label');
-      searchSearchLabel.type.should.equal('a');
-      searchSearchLabel.props.href.should.equal('http://www.economist.com/search/');
-      searchSearchClose.props.className.should.equal('search__search-close');
-      searchSearchClose.type.should.equal('a');
-      searchSearchClose.props.onClick.should.be.a('function');
-    });
   });
 });
+


### PR DESCRIPTION
This PR aims to remove all of the hide/show logic from this component, which now is only responsible of loading the Google Custom Search script.

Be sure https://github.com/economist-components/component-navigation/pull/35 is merged too.