### PR TITLE
feat: make div IDs for google search box unique

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,24 +3,12 @@ import React from 'react';
 import ReactDom from 'react-dom';
 import promisescript from 'promisescript';
 
+function randomHex() {
+  return Math.floor(Math.random() * 10000).toString(16);  // eslint-disable-line no-magic-numbers
+}
+
 let googleScript = null;
 export default class GoogleSearch extends React.Component {
-
-  static get propTypes() {
-    return {
-      enableHistory: React.PropTypes.bool,
-      noResultsString: React.PropTypes.string,
-      newWindow: React.PropTypes.bool,
-      gname: React.PropTypes.string,
-      queryParameterName: React.PropTypes.string,
-      language: React.PropTypes.string,
-      resultsUrl: React.PropTypes.string,
-      cx: React.PropTypes.string, // eslint-disable-line id-length
-      googleScriptUrl: React.PropTypes.string,
-      autoFocus: React.PropTypes.bool,
-    };
-  }
-
   static get defaultProps() {
     return {
       enableHistory: true,
@@ -40,11 +28,15 @@ export default class GoogleSearch extends React.Component {
 
   constructor(props) {
     super(props);
-    this.state = {
+    this.assignRef = this.assignRef.bind(this);
+  }
+
+  componentWillMount() {
+    this.setState({
+      divID: this.props.divID || `google-search-box-${ randomHex() }`,
       // useFallback by default on SS
       useFallback: (typeof window === 'undefined'),
-    };
-    this.assignRef = this.assignRef.bind(this);
+    });
   }
 
   componentDidMount() {
@@ -70,7 +62,7 @@ export default class GoogleSearch extends React.Component {
 
   displayGoogleSearch() {
     const config = {
-      div: 'google-search-box',
+      div: this.state.divID,
       tag: 'searchbox-only',
       attributes: {
         enableHistory: this.props.enableHistory,
@@ -116,7 +108,7 @@ export default class GoogleSearch extends React.Component {
 
   render() {
     return (
-      <div className="google-search" id="google-search-box">
+      <div className="google-search" id={this.state.divID}>
         <div className="fallback" style={{ display: (this.state.useFallback) ? 'block' : 'none' }}>
           <form
             acceptCharset="UTF-8"
@@ -146,3 +138,20 @@ export default class GoogleSearch extends React.Component {
     );
   }
 }
+
+if (process.env.NODE_ENV === 'production') {
+  GoogleSearch.propTypes = {
+    enableHistory: React.PropTypes.bool,
+    noResultsString: React.PropTypes.string,
+    newWindow: React.PropTypes.bool,
+    gname: React.PropTypes.string,
+    queryParameterName: React.PropTypes.string,
+    language: React.PropTypes.string,
+    resultsUrl: React.PropTypes.string,
+    cx: React.PropTypes.string, // eslint-disable-line id-length
+    googleScriptUrl: React.PropTypes.string,
+    autoFocus: React.PropTypes.bool,
+    divID: React.PropTypes.string,
+  };
+}
+

--- a/test/index.js
+++ b/test/index.js
@@ -9,6 +9,11 @@ chai.use(chaiEnzyme()).should();
 chai.use(chaiSpies);
 
 describe('GoogleSearch', () => {
+  let comp = null;
+  beforeEach(() => {
+    comp = new GoogleSearch({}, {}, {});
+  });
+
   it('is compatible with React.Component', () => {
     GoogleSearch.should.be.a('function')
       .and.respondTo('render');
@@ -25,10 +30,35 @@ describe('GoogleSearch', () => {
     wrapper.state().useFallback.should.equal(false);
   });
 
+  describe('componentWillMount', () => {
+    const oldMathRandom = Math.random;
+    afterEach(() => {
+      Math.random = oldMathRandom;
+    });
+    it('calls setState with this.props.divID', () => {
+      comp.props.divID = 'test-div-id';
+      comp.setState = chai.spy();
+      comp.componentWillMount();
+      comp.setState.should.have.been.called.with({
+        divID: 'test-div-id',
+        useFallback: (typeof window === 'undefined'),
+      });
+    });
+    it('calls setState with a random hash if this.props.divID is not present', () => {
+      comp.props.divID = null;
+      Math.random = () => 0.1234;
+      const multipliedAndInHex = (1234).toString(16);
+      comp.setState = chai.spy();
+      comp.componentWillMount();
+      comp.setState.should.have.been.called.with({
+        divID: `google-search-box-${ multipliedAndInHex }`,
+        useFallback: (typeof window === 'undefined'),
+      });
+    });
+  });
+
   describe('focusSearchField', () => {
-    let comp = null;
     beforeEach(() => {
-      comp = new GoogleSearch({}, {}, {});
       comp.googleSearchInput = { focus: chai.spy() };
     });
     it('focuses the element when the autoFocus prop is true', () => {


### PR DESCRIPTION
Previously, two GoogleSearch components on the same page would collide since they would both output a div with the ID `google-search-box`. Now it uses `Math.random` by default, and `divID` to generate a fixed ID (useful for serverside rendering, where client and server output should be deterministic).