### PR TITLE
fix: TEC-1345: default to fallback until google script is ready

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,8 +35,8 @@ export default class GoogleSearch extends React.Component {
   componentWillMount() {
     this.setState({
       divID: this.props.divID || `google-search-box-${ randomHex() }`,
-      // useFallback by default on SS
-      useFallback: (typeof window === 'undefined'),
+      // useFallback by default
+      useFallback: true,
     });
   }
 
@@ -46,6 +46,7 @@ export default class GoogleSearch extends React.Component {
         if (this.unmounted) {
           return;
         }
+        this.setState({}, this.state, { useFallback: false });
         this.displayGoogleSearch();
         this.focusSearchField();
       })


### PR DESCRIPTION
fallback is true by default, so we get consistent rendering by both server and client.
Then ,once the client finishes loading the google stuff, the fallback is then discarded for the google component.